### PR TITLE
V2.18.1 — Fix arrondi unités discrètes (œufs, gousses…)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 
 # --- Notes locales Claude Code (ne jamais publier) ---
 CLAUDE.local.md
+tâches/

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.18.0</title>
+<title>Menu IG Bas — V2.18.1</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -9634,12 +9634,21 @@ function prettyNumber(qty) {
 // référencé, on affiche "N (≈Xg/pièce)" pour que l'utilisateur voie le poids d'une pièce.
 function formatQty(qty, unit, name) {
   const u = dataRef.canonicalUnit(unit);
+  // Unités discrètes (œuf, gousse, c.à.c, c.à.s, u, pincée…) : arrondi à
+  // l'entier dès que qty ≥ 0,75. Sous ce seuil on garde l'affichage
+  // fractionnaire (½ pomme, ¼ gousse, 0,5 c.à.c…) qui a du sens en cuisine.
+  const isDiscrete = dataRef.isDiscreteUnit(u);
   if (u === "u" && name) {
     const w = dataRef.produceUnitWeight(canonicalName(name));
     if (w) {
-      const total = Math.round(qty * w);
-      return `${prettyNumber(qty)} u (≈${w} g/pièce soit ${total} g)`;
+      const displayQty = qty >= 0.75 ? Math.round(qty) : qty;
+      const display = qty >= 0.75 ? String(displayQty) : prettyNumber(qty);
+      const total = Math.round(displayQty * w);
+      return `${display} u (≈${w} g/pièce soit ${total} g)`;
     }
+  }
+  if (isDiscrete && qty >= 0.75) {
+    return `${Math.round(qty)} ${unit}`;
   }
   const rounded = Math.round(qty * 10) / 10;
   const asStr = Number.isInteger(rounded) ? String(rounded) : String(rounded).replace(".", ",");

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.18.0";
+const CACHE_VERSION = "menu-ig-bas-v2.18.1";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
- Patch de la fonction d'affichage des quantités (`index.html` ligne 9635) : arrondi entier (`Math.round`) pour les unités discrètes (œuf, gousse, c.à.s, c.à.c, u, pincée…) dès qty ≥ 0,75. Sous ce seuil, fractions ½ ¼ ⅓ 0,5 préservées.
- Bump `<title>` et `CACHE_VERSION` en V2.18.1.
- Privacy : ajout `tâches/` au `.gitignore` (notes locales workflow Claude Code, repo public).

## Contexte
Bug remonté après 3 semaines d'usage réel : la fiche recette affichait des quantités fractionnaires absurdes (« 3,7 œufs », « 8,8 gousses d'ail ») parce que l'arrondi par défaut était à 0,1 décimale même pour les unités discrètes. La fonction d'agrégation côté liste de courses (ligne 9700) faisait déjà le bon arrondi `ceil` — ce patch corrige l'asymétrie côté fiche recette.

## Limite connue (hors scope de cette PR)
Le calibrage absolu des aromates reste un sujet : un Dahl pour 4 personnes affichera 4 oignons + 9 gousses d'ail, ce qui reste trop. Bug structurel de scaling linéaire (les aromates devraient scaler en `× √n` plutôt que `× n`), à traiter en V2.19.0. Cf `tâches/leçons.md` #12 et `tâches/a-faire.md` Phase 2.

## Test plan
- [x] Title V2.18.1 servi via http://localhost:8765
- [x] CACHE_VERSION v2.18.1 dans sw.js servi
- [x] 9 tables JSON validées (parse Python)
- [x] Test visuel sur quelques recettes (Dahl `d83`, breakfast `b2`, recette avec ½ ingrédient)
- [ ] Après merge sur `main` : déploiement GitHub Pages effectif sur https://rhomark.github.io/menu-ig-bas/ (~1-2 min après merge)
- [ ] Reload PWA pour confirmer que le SW bascule sur la nouvelle CACHE_VERSION

🤖 Generated with [Claude Code](https://claude.com/claude-code)
