### PR TITLE
V2.19.0 — Scaling sub-linéaire des aromates (ail, oignon, épices…)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.18.1</title>
+<title>Menu IG Bas — V2.19.0</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -9481,6 +9481,45 @@ function mealEquivalents(profile, attendees) {
     .filter(m => attendees.includes(m.id))
     .reduce((s,m) => s + adultEquivalent(m), 0) || 0;
 }
+
+// ---------------------------------------------------------------------------
+// Scaling sub-linéaire des aromates (V2.19.0)
+// ---------------------------------------------------------------------------
+// Les aromates (ail, oignon, échalote, gingembre, herbes, épices, sauces,
+// vinaigres, citron…) ne suivent pas un scaling linéaire avec le nombre de
+// mangeurs : un Dahl pour 8 personnes prend 3-4 gousses d'ail, pas 8.
+// Référence terrain : ≤ 3 gousses + ≤ 2 oignons par 4 portions (cf
+// tâches/leçons.md #12). Application : qty × √mult au lieu de qty × mult.
+// Toutes les entrées de category "spices" sont aromatic by default ; pour
+// les autres catégories, la liste explicite ci-dessous fait foi.
+const NON_SPICES_AROMATICS = new Set([
+  // produce — herbes fraîches + alliacées + agrumes utilisés comme aromate
+  "ail", "aneth", "aneth ou ciboulette", "basilic", "ciboulette",
+  "coriandre", "echalote", "estragon", "feuille de basilic thai",
+  "gingembre", "herbe", "menthe",
+  "oignon", "oignon / ciboule", "oignon nouveau", "oignon nouveaux", "oignon rouge",
+  "persil", "persil plat", "romarin",
+  "citron", "citron vert",
+  // pantry — sauces, vinaigres, condiments concentrés, levures
+  "moutarde", "moutarde a l'ancienne", "pate de miso",
+  "sauce nuoc-mam", "sauce soja", "sauce soja salee",
+  "vinaigre balsamique", "vinaigre blanc", "vinaigre de cidre",
+  "vinaigre de vin", "vinaigre de xere", "vinaigrette maison",
+  "concentre de tomate", "levure chimique",
+]);
+function isAromatic(canonName, category) {
+  if (category === "spices") return true;
+  return NON_SPICES_AROMATICS.has(canonName);
+}
+function scaleQty(baseQty, mult, ingredientName, category) {
+  if (mult <= 0 || !Number.isFinite(mult)) return baseQty;
+  const canon = canonicalName(ingredientName);
+  if (isAromatic(canon, category)) {
+    return baseQty * Math.sqrt(mult);
+  }
+  return baseQty * mult;
+}
+
 function ingredientHasAllergen(ing, allergens) {
   // Very conservative: allergens are declared on recipe level. No fuzzy match.
   return false;
@@ -10454,7 +10493,7 @@ function aggregateShoppingList(weekMenu, profile) {
         if (!agg[key]) {
           agg[key] = {name: displayCanonName(cName), qty: 0, unit: cUnit, category};
         }
-        agg[key].qty += cQty * mult;
+        agg[key].qty += scaleQty(cQty, mult, cName, category);
       });
     });
   });
@@ -11629,7 +11668,7 @@ function RecipeModal({recipe, profile, attendees, rating, onRate, onClose}) {
               {recipe.ing.map(([name,qty,unit,cat],i) => (
                 <li key={i} className="flex justify-between text-sm border-b border-dashed border-slate-200 dark:border-slate-700 py-1">
                   <span>{name}</span>
-                  <span className="font-mono text-slate-600 dark:text-slate-300">{formatQty(qty*mult, unit, name)}</span>
+                  <span className="font-mono text-slate-600 dark:text-slate-300">{formatQty(scaleQty(qty, mult, name, cat), unit, name)}</span>
                 </li>
               ))}
             </ul>

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.18.1";
+const CACHE_VERSION = "menu-ig-bas-v2.19.0";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
- Nouvelle fonction `scaleQty(baseQty, mult, name, category)` : applique `qty × √mult` aux aromatiques au lieu de `qty × mult` (scaling sub-linéaire).
- Détection des aromatiques : tous les `category: "spices"` + une liste explicite `NON_SPICES_AROMATICS` (ail, oignons, échalote, gingembre, herbes fraîches, citron, sauces, vinaigres, condiments concentrés, levure chimique).
- 2 points d'application du multiplicateur famille (`index.html:10457` agrégation liste de courses + `index.html:11632` affichage fiche recette) basculés sur `scaleQty()`.
- Le calcul de coût total (`index.html:10485`) reste linéaire — coût réel à payer, indépendant du scaling culinaire.
- Bump `<title>` et `CACHE_VERSION` en V2.19.0.

## Contexte
Bug structurel remonté après 3 semaines d'usage : pour un foyer 2 adultes + 2 ados (mult = 4,4 adult-equivalents), un Dahl affichait **4 oignons + 9 gousses d'ail** alors que la règle terrain culinaire est ≤ 2 oignons + ≤ 3 gousses pour 4 portions. Cause : scaling linéaire `qty × mult` appliqué à tous les ingrédients alors qu'en cuisine, les aromates ne se multiplient pas linéairement avec le nombre de mangeurs (un Dahl pour 8 personnes prend 3-4 gousses, pas 8). Cf `tâches/leçons.md` #12.

## Effet chiffré sur Dahl `d83` (foyer 4,4 adult-eq)

| Ingrédient | V2.18.1 | V2.19.0 | Catégorie scaling |
|---|---|---|---|
| Riz basmati complet | 440 g | 440 g | linéaire |
| Lentilles corail | 660 g | 660 g | linéaire |
| Lait de coco | 880 ml | 880 ml | linéaire |
| Tomate concassée | 880 g | 880 g | linéaire |
| **Oignon** | 4 (4,4) | **2** | aromatique ✓ règle terrain |
| **Ail** | 9 (8,8) | **4** | aromatique (>3 idéal — Phase 4 affinera la base stockée) |
| **Gingembre frais** | 44 g | **21 g** | aromatique |
| **Curry/Curcuma/Cumin** | 4 c.à.c | **2** | aromatique |
| **Citron jus** | 2 | **1** | aromatique |
| **Sel** | 4 pincées | **2** | aromatique |
| Huile d'olive | 4 c.à.s | 4 c.à.s | linéaire (par défaut) |

## Limite connue (hors scope)
La règle terrain "≤ 3 gousses d'ail" n'est pas strictement respectée (4 affichées au lieu de 3) car la base stockée dans `data-recipes` reste à 2 gousses adult-eq. Pour matcher exactement, il faudrait recalibrer la base à 1,5 gousse — chantier de Phase 4 (audit qualité base existante).

## Test plan
- [x] Title V2.19.0 servi via http://localhost:8765
- [x] CACHE_VERSION v2.19.0 dans sw.js servi
- [x] 9 tables JSON validées
- [x] Simulation chiffrée Python du `scaleQty()` sur Dahl d83 → résultats attendus confirmés
- [ ] Test visuel HedgeX sur 3-4 recettes (Dahl `d83`, plat avec curry/cumin, plat avec citron, plat sans aromate pour vérifier non-régression linéaire)
- [ ] Vérifier la liste de courses agrégée (somme sur la semaine) : aromates également scalés sub-linéaire
- [ ] Après merge sur `main` : déploiement GitHub Pages effectif sur https://rhomark.github.io/menu-ig-bas/ (~1-2 min)
- [ ] Reload PWA pour confirmer bascule du SW sur la nouvelle CACHE_VERSION

🤖 Generated with [Claude Code](https://claude.com/claude-code)
