### PR TITLE
V2.19.2 — Footer en lecture dynamique de la version (fix oubli systémique)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,12 @@ python3 -m http.server 8000
 
 Sinon les utilisateurs gardent l'ancienne version en cache.
 
+**Le footer UI et `appVersion` (logique d'import) lisent la version
+dynamiquement depuis `document.title` — pas de bump manuel à faire**
+(régression réparée en V2.19.2 après 3 oublis successifs).
+Vérification : `grep -nE 'V\d+\.\d+\.\d+' index.html sw.js` doit ne
+matcher que les 2 endroits ci-dessus + des commentaires d'historique.
+
 ## Glossaire métier
 
 - **IG** (Index Glycémique) : 0-100. IG bas ≤ 55.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.19.1</title>
+<title>Menu IG Bas — V2.19.2</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -10941,7 +10941,7 @@ function App({initialState}) {
         />
       )}
       <footer className="no-print bg-slate-900 text-slate-400 dark:text-slate-500 text-center py-3 text-xs">
-        Menu IG Bas V2.18.0 — prototype local • Données stockées dans votre navigateur ·{" "}
+        Menu IG Bas {(/V\d+\.\d+\.\d+/.exec(document.title)?.[0]) || ""} — prototype local • Données stockées dans votre navigateur ·{" "}
         <a href="https://github.com/RhoMark/menu-ig-bas/blob/main/PRIVACY.md"
           target="_blank" rel="noopener noreferrer"
           className="underline hover:text-slate-200">Confidentialité</a>

--- a/index.html
+++ b/index.html
@@ -12821,7 +12821,7 @@ function PrintMenuPage({weekStart, menu, profile}) {
           ))}
         </tbody>
       </table>
-      <p className="text-[8pt] text-slate-500 dark:text-slate-400 mt-3 text-center">Menu IG Bas V2.18.0 · prototype</p>
+      <p className="text-[8pt] text-slate-500 dark:text-slate-400 mt-3 text-center">Menu IG Bas {(/V\d+\.\d+\.\d+/.exec(document.title)?.[0]) || ""} · prototype</p>
     </div>
   );
 }

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.19.1";
+const CACHE_VERSION = "menu-ig-bas-v2.19.2";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
- **Footer principal** (`index.html` ligne 10944) et **footer d'impression A4** (`index.html` ligne 12824) basculés en lecture dynamique de la version depuis `document.title`. Plus jamais d'oubli de bump à ces 2 endroits.
- `CLAUDE.md` projet : section "Versionnage — à bumper ENSEMBLE" mise à jour pour préciser que les footers et `appVersion` lisent dynamiquement, et donner la commande `grep` de vérification avant commit.
- Bump `<title>` et `CACHE_VERSION` en V2.19.2.

## Contexte
HedgeX a remonté que le footer affichait toujours `V2.18.0` alors qu'on était en V2.19.1 effective. **Oubli systémique sur 3 versions consécutives** (V2.18.1, V2.19.0, V2.19.1) car la règle "À bumper ENSEMBLE" du `CLAUDE.md` projet ne listait que `<title>` et `CACHE_VERSION`. Le footer était hardcodé.

Le grep de vérification post-fix a même trouvé un **deuxième endroit oublié** : le footer du rendu d'impression A4 ligne 12824 (cf 2e commit de cette PR). Validation par grep systématique adoptée comme bonne pratique.

## Détails — pattern adopté

```jsx
Menu IG Bas {(/V\d+\.\d+\.\d+/.exec(document.title)?.[0]) || ""} ...
```

Approche cohérente avec ce qui était déjà en place pour `appVersion` (logique d'import, ligne 12292) qui lit aussi du `document.title`. Une seule source de vérité pour la version (le `<title>`) + `CACHE_VERSION` indépendant pour invalider le cache PWA.

## Doc projet et leçons
- `CLAUDE.md` projet — section versionnage enrichie avec note "footer en dynamique" + commande de vérification (`grep -nE 'V\d+\.\d+\.\d+'`)
- `tâches/leçons.md` (privé, non commité) — leçon #15 capturée

## Test plan
- [x] grep `'Menu IG Bas V[0-9]'` retourne 0 match dans `index.html` (plus aucun hardcoded)
- [x] grep `'V\d+\.\d+\.\d+'` ne match plus que `<title>` + `CACHE_VERSION` + commentaires d'historique
- [ ] Après merge sur `main` : déploiement GitHub Pages effectif (~1-2 min)
- [ ] Vérif visuelle du footer (V2.19.2 affichée dynamiquement)
- [ ] Vérif visuelle du rendu d'impression A4 (footer V2.19.2 en bas du planning imprimé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
