### PR TITLE
V2.20.1 — Ajout des 7 autres équipements (BBQ, Wok, Multicuiseur…)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.20.0</title>
+<title>Menu IG Bas — V2.20.1</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -125,10 +125,17 @@ if ("serviceWorker" in navigator) {
   "items": [
     {"id": "stove",           "label": "Plaques / poêle"},
     {"id": "oven",            "label": "Four"},
+    {"id": "microwave",       "label": "Micro-ondes"},
     {"id": "blender",         "label": "Mixeur / blender"},
+    {"id": "stand-mixer",     "label": "Robot pâtissier"},
     {"id": "grill",           "label": "Gril / plancha"},
+    {"id": "bbq",             "label": "Barbecue"},
+    {"id": "wok",             "label": "Wok"},
     {"id": "pressure-cooker", "label": "Autocuiseur"},
+    {"id": "multi-cooker",    "label": "Multicuiseur (Cookéo, Instant Pot…)"},
     {"id": "air-fryer",       "label": "Air Fryer"},
+    {"id": "steamer",         "label": "Cuiseur vapeur"},
+    {"id": "cast-iron",       "label": "Cocotte en fonte"},
     {"id": "bowl",            "label": "Saladier / bol"}
   ]
 }

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.20.0";
+const CACHE_VERSION = "menu-ig-bas-v2.20.1";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
- Ajout des **7 équipements manquants** dans `data-equipment` : `microwave`, `stand-mixer`, `bbq`, `wok`, `multi-cooker`, `steamer`, `cast-iron`.
- `grill` conservé tel quel (label "Gril / plancha"), sans décomposition `grill-oven` / `plancha` séparée — pas de migration des 5 recettes existantes qui l'utilisent.
- Bump V2.20.0 → V2.20.1 (`<title>` + `CACHE_VERSION`).

## Contexte
Correction de V2.20.0 qui n'avait ajouté que `air-fryer` parmi les 8 équipements de l'issue #52. Mauvaise interprétation de la consigne brève — cf leçon #17 capturée dans `tâches/leçons.md` sur le pattern récurrent de **sous-interprétation** des consignes brèves.

## Total équipements

**Avant V2.20.0** : 6 (stove, oven, blender, grill, pressure-cooker, bowl)
**Après V2.20.0** : 7 (+ air-fryer)
**Après V2.20.1 (cette PR)** : **14** (+ microwave, stand-mixer, bbq, wok, multi-cooker, steamer, cast-iron)

| ID | Label | Notes |
|---|---|---|
| `stove` | Plaques / poêle | inchangé |
| `oven` | Four | inchangé |
| `microwave` | Micro-ondes | nouveau |
| `blender` | Mixeur / blender | inchangé |
| `stand-mixer` | Robot pâtissier | nouveau |
| `grill` | Gril / plancha | inchangé (couvre les 5 recettes plancha-style existantes) |
| `bbq` | Barbecue | nouveau |
| `wok` | Wok | nouveau |
| `pressure-cooker` | Autocuiseur | inchangé |
| `multi-cooker` | Multicuiseur (Cookéo, Instant Pot…) | nouveau |
| `air-fryer` | Air Fryer | V2.20.0 (label anglais comme demandé) |
| `steamer` | Cuiseur vapeur | nouveau |
| `cast-iron` | Cocotte en fonte | nouveau |
| `bowl` | Saladier / bol | inchangé |

## Décision design — `grill` reste générique
Audit des recettes existantes : les 5 recettes utilisant `grill` (l1, d39, d42, d63, d90) sont **toutes** des préparations plancha-style (poulet grillé été, brochettes, daurade plancha). Le label "Gril / plancha" reste cohérent. Pas de décomposition `grill` → `grill-oven` / `plancha` / `bbq` pour éviter migration des recettes. Si HedgeX souhaite cette décomposition plus tard, elle fera l'objet d'une PR dédiée avec script de migration.

## Test plan
- [x] data-equipment validé (14 entrées, JSON OK)
- [x] Title V2.20.1 + CACHE_VERSION v2.20.1 alignés
- [ ] Après merge sur `main` : déploiement GitHub Pages effectif (~1-2 min)
- [ ] Test UI Paramètres foyer : 14 équipements sélectionnables, cohérence visuelle
- [ ] Vérifier qu'aucune recette existante n'est devenue ineligible (les 5 recettes `grill` doivent toujours apparaître pour les foyers ayant coché `grill`)

## Issue #52 — sera fermée à la suite de ce merge
Tous les équipements de la liste sont désormais dans `data-equipment`. La question design `grill` décomposé reste ouverte pour décision future si nécessaire, mais l'issue principale (extension des équipements) est résolue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
