### PR TITLE
V2.21.2 — Fix : dropdown profil santé aussi dans SettingsView

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.21.1</title>
+<title>Menu IG Bas — V2.21.2</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -12997,6 +12997,11 @@ function SettingsView({state, update, updateProfile}) {
                 </div>
                 <select value={m.sex} onChange={e=>updateMember(m.id,{sex:e.target.value})} className="border rounded px-2 py-1">
                   <option value="F">F</option><option value="M">M</option><option value="X">Autre</option>
+                </select>
+                <select value={m.healthProfile || "healthy"} onChange={e=>updateMember(m.id,{healthProfile:e.target.value})} className="border rounded px-2 py-1 min-w-[180px]" title="Profil santé : détermine le seuil de charge glycémique journalière. Pour le foyer, le profil le plus contraignant gagne.">
+                  {Object.entries(HEALTH_PROFILE_LABELS).map(([key, label]) => (
+                    <option key={key} value={key}>{label}</option>
+                  ))}
                 </select>
                 {p.members.length > 1 && <button onClick={()=>removeMember(m.id)} className="text-red-500 text-sm">Retirer</button>}
               </div>

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.21.1";
+const CACHE_VERSION = "menu-ig-bas-v2.21.2";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
- Ajout du dropdown "Profil santé" dans **`SettingsView`** (ligne 12998), à côté de l'éditeur de membres existant.
- Bump V2.21.1 → V2.21.2 (`<title>` + `CACHE_VERSION`).

## Bug d'origine
HedgeX a remonté ne pas voir le dropdown profil santé. Le code de V2.21.0 a été ajouté dans **`SetupView`** (wizard d'onboarding initial, ligne 11550) seulement — donc invisible pour les utilisateurs déjà onboardés (qui éditent les membres via `SettingsView`).

Diagnostic : 2 composants distincts rendent l'éditeur de membres dans le projet (mono-fichier React) :
- `SetupView` ligne 11550 (onboarding initial, vu une seule fois)
- `SettingsView` ligne 12746 (paramètres permanents)

Modifier l'un sans l'autre = UI cassée pour la moitié des utilisateurs.

## Fix
Ajout du même dropdown dans `SettingsView`, après le `<select>` Sexe et avant le bouton Retirer :

```jsx
<select value={m.healthProfile || "healthy"}
        onChange={e=>updateMember(m.id,{healthProfile:e.target.value})}
        className="border rounded px-2 py-1 min-w-[180px]"
        title="Profil santé : détermine le seuil de charge glycémique journalière. Pour le foyer, le profil le plus contraignant gagne.">
  {Object.entries(HEALTH_PROFILE_LABELS).map(([key, label]) => (
    <option key={key} value={key}>{label}</option>
  ))}
</select>
```

Vérif : `grep -c healthProfile.*onChange index.html` retourne maintenant **2** (SetupView + SettingsView).

## Leçon #18 capturée
Pattern récidive de **mod incomplète** (cohérent avec leçons #15 sur les bumps version oubliés et #17 sur la sous-interprétation). Antidote formalisé dans `tâches/leçons.md` : avant tout Edit UI ciblé, grep le pattern clé sur tout le fichier pour détecter les duplicatas.

## Test plan
- [x] 9 tables JSON valides
- [x] `grep -c "healthProfile.*onChange"` = 2
- [x] Bump versions alignées
- [ ] Test visuel après merge : Paramètres > Membres → dropdown "Sans contraintes IG/CG" / "Diabète T2" / etc. visible
- [ ] Test rétrocompatibilité onboarding : nouveaux utilisateurs voient le dropdown dans SetupView aussi (V2.21.0 inchangée sur ce point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
