### PR TITLE
V2.23.0 — Phase 3 finale : intégration garde-fou CG dans generateWeek

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.22.0</title>
+<title>Menu IG Bas — V2.23.0</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -11249,70 +11249,107 @@ function generateWeek({profile, ratings, menus, weekStart, keepLocked}) {
   const dessertsCooldown = recentMealSlots(menus, weekStart, "dessert", 7);
   const snacksCooldown   = recentMealSlots(menus, weekStart, "snack",   7);
 
+  // Garde-fou CG journalier (V2.23.0) : on tente jusqu'à 3 fois la génération
+  // d'une journée si elle dépasse le seuil "high" du foyer. Le seuil dépend du
+  // profil santé du membre le plus contraignant (cf householdCgTarget). Tiers
+  // low / medium / unknown sont acceptés ; seul "high" déclenche un re-roll.
+  // Au-delà de 3 tentatives ou si le pool est trop pauvre, on accepte le
+  // dernier essai (best-effort, l'UI affichera le badge orange/rouge).
+  const cgTarget = householdCgTarget(profile);
+  const CG_MAX_DAY_ATTEMPTS = 3;
+
   DAYS.forEach((day, i) => {
     const prev = existing[day] || {};
     const locked = prev.locked || {};
-    const slot = {locked: {...locked}};
-    // préserver l'attendance existante
-    if (prev.attendance) slot.attendance = prev.attendance;
 
-    // Breakfast: rotation déterministe pour garantir 7 petits-déjs différents si possible
-    if (keepLocked && locked.breakfast && prev.breakfast) {
-      slot.breakfast = prev.breakfast;
-    } else if (breakfasts.length > 0) {
-      slot.breakfast = breakfasts[i % breakfasts.length].id;
-    }
+    let slot = null;
+    let attempt = 0;
+    while (attempt < CG_MAX_DAY_ATTEMPTS) {
+      attempt++;
+      // Snapshot des sets mutables pour pouvoir restorer en cas de re-roll
+      const usedSnapshot     = new Set(usedThisWeek);
+      const dessertsSnapshot = new Set(dessertsCooldown);
+      const snacksSnapshot   = new Set(snacksCooldown);
 
-    // Lunch
-    if (keepLocked && locked.lunch && prev.lunch) {
-      slot.lunch = prev.lunch;
-      usedThisWeek.add(prev.lunch);
-    } else {
-      const picked = pickFromPool(lunches, {hardAvoid: usedThisWeek, softAvoid: recentlyUsed, lastUsedMap, ratings});
-      if (picked) { slot.lunch = picked.id; usedThisWeek.add(picked.id); }
-    }
+      slot = {locked: {...locked}};
+      // préserver l'attendance existante
+      if (prev.attendance) slot.attendance = prev.attendance;
 
-    // Dinner — anti-doublon semaine + anti-récurrence 3 mois + pas le même féculent/légumineuse que le lunch du jour
-    if (keepLocked && locked.dinner && prev.dinner) {
-      slot.dinner = prev.dinner;
-      usedThisWeek.add(prev.dinner);
-    } else {
-      let dinnerPool = dinners;
-      const lunchRecipe = slot.lunch ? RECIPES.find(r => r.id === slot.lunch) : null;
-      if (lunchRecipe) {
-        const lunchStaples = recipeStaples(lunchRecipe);
-        if (lunchStaples.size > 0) {
-          const filtered = dinners.filter(r => {
-            const ds = recipeStaples(r);
-            for (const s of lunchStaples) if (ds.has(s)) return false;
-            return true;
-          });
-          // Filtre conservé seulement si ≥ 3 candidats — sinon mieux vaut un doublon staple qu'un slot dégradé.
-          if (filtered.length >= 3) dinnerPool = filtered;
+      // Breakfast: rotation déterministe pour garantir 7 petits-déjs différents si possible
+      if (keepLocked && locked.breakfast && prev.breakfast) {
+        slot.breakfast = prev.breakfast;
+      } else if (breakfasts.length > 0) {
+        slot.breakfast = breakfasts[(i + attempt - 1) % breakfasts.length].id;
+      }
+
+      // Lunch
+      if (keepLocked && locked.lunch && prev.lunch) {
+        slot.lunch = prev.lunch;
+        usedThisWeek.add(prev.lunch);
+      } else {
+        const picked = pickFromPool(lunches, {hardAvoid: usedThisWeek, softAvoid: recentlyUsed, lastUsedMap, ratings});
+        if (picked) { slot.lunch = picked.id; usedThisWeek.add(picked.id); }
+      }
+
+      // Dinner — anti-doublon semaine + anti-récurrence 3 mois + pas le même féculent/légumineuse que le lunch du jour
+      if (keepLocked && locked.dinner && prev.dinner) {
+        slot.dinner = prev.dinner;
+        usedThisWeek.add(prev.dinner);
+      } else {
+        let dinnerPool = dinners;
+        const lunchRecipe = slot.lunch ? RECIPES.find(r => r.id === slot.lunch) : null;
+        if (lunchRecipe) {
+          const lunchStaples = recipeStaples(lunchRecipe);
+          if (lunchStaples.size > 0) {
+            const filtered = dinners.filter(r => {
+              const ds = recipeStaples(r);
+              for (const s of lunchStaples) if (ds.has(s)) return false;
+              return true;
+            });
+            // Filtre conservé seulement si ≥ 3 candidats — sinon mieux vaut un doublon staple qu'un slot dégradé.
+            if (filtered.length >= 3) dinnerPool = filtered;
+          }
+        }
+        const picked = pickFromPool(dinnerPool, {hardAvoid: usedThisWeek, softAvoid: recentlyUsed, lastUsedMap, ratings});
+        if (picked) { slot.dinner = picked.id; usedThisWeek.add(picked.id); }
+      }
+
+      // Snack (goûter) — anti-doublon sur 8 jours glissants (cf. snacksCooldown)
+      if (profile.snackEnabled) {
+        if (keepLocked && locked.snack && prev.snack) {
+          slot.snack = prev.snack;
+          snacksCooldown.add(prev.snack);
+        } else if (snacks.length > 0) {
+          const picked = pickFromPool(snacks, {hardAvoid: snacksCooldown, ratings});
+          if (picked) { slot.snack = picked.id; snacksCooldown.add(picked.id); }
         }
       }
-      const picked = pickFromPool(dinnerPool, {hardAvoid: usedThisWeek, softAvoid: recentlyUsed, lastUsedMap, ratings});
-      if (picked) { slot.dinner = picked.id; usedThisWeek.add(picked.id); }
-    }
 
-    // Snack (goûter) — anti-doublon sur 8 jours glissants (cf. snacksCooldown)
-    if (profile.snackEnabled) {
-      if (keepLocked && locked.snack && prev.snack) {
-        slot.snack = prev.snack;
-        snacksCooldown.add(prev.snack);
-      } else if (snacks.length > 0) {
-        const picked = pickFromPool(snacks, {hardAvoid: snacksCooldown, ratings});
-        if (picked) { slot.snack = picked.id; snacksCooldown.add(picked.id); }
+      // Dessert — 1 par jour, anti-doublon sur 8 jours glissants (cf. dessertsCooldown)
+      if (keepLocked && locked.dessert && prev.dessert) {
+        slot.dessert = prev.dessert;
+        dessertsCooldown.add(prev.dessert);
+      } else if (desserts.length > 0) {
+        const picked = pickFromPool(desserts, {hardAvoid: dessertsCooldown, ratings});
+        if (picked) { slot.dessert = picked.id; dessertsCooldown.add(picked.id); }
       }
-    }
 
-    // Dessert — 1 par jour, anti-doublon sur 8 jours glissants (cf. dessertsCooldown)
-    if (keepLocked && locked.dessert && prev.dessert) {
-      slot.dessert = prev.dessert;
-      dessertsCooldown.add(prev.dessert);
-    } else if (desserts.length > 0) {
-      const picked = pickFromPool(desserts, {hardAvoid: dessertsCooldown, ratings});
-      if (picked) { slot.dessert = picked.id; dessertsCooldown.add(picked.id); }
+      // Garde-fou CG : calculer le tier de la journée. On accepte tout sauf
+      // "high" (au-dessus du seuil élevé du foyer). On accepte aussi
+      // "unknown" (data-glycemic insuffisante) pour ne pas bloquer.
+      const dayCg = computeDayCg({[day]: slot}, day, profile);
+      const tier = dayCgTier(dayCg.covered > 0 ? dayCg.cg : null, cgTarget);
+      if (tier !== "high") break;
+
+      // tier "high" → re-roll. On restaure les sets pour la prochaine tentative.
+      // Les recettes choisies durant cette tentative sont retirées des sets
+      // afin que le re-roll puisse les sélectionner à nouveau pour un autre
+      // jour ou les éviter pour celui-ci si le pickFromPool tire ailleurs.
+      if (attempt < CG_MAX_DAY_ATTEMPTS) {
+        usedThisWeek.clear();     usedSnapshot.forEach(id => usedThisWeek.add(id));
+        dessertsCooldown.clear(); dessertsSnapshot.forEach(id => dessertsCooldown.add(id));
+        snacksCooldown.clear();   snacksSnapshot.forEach(id => snacksCooldown.add(id));
+      }
     }
 
     days[day] = slot;

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.22.0";
+const CACHE_VERSION = "menu-ig-bas-v2.23.0";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
Phase 3 finale : le garde-fou CG journalier devient **ACTIF** dans la génération automatique de menu (plus seulement informationnel comme en V2.21.x).

- Refactor `generateWeek()` (`index.html` ligne 11220) : retry-loop autour de la boucle DAYS avec snapshot/restore des sets mutables.
- `CG_MAX_DAY_ATTEMPTS = 3` : tente jusqu'à 3 fois une journée si tier "high", accepte sinon.
- Compatible avec locked slots et toutes les contraintes existantes (anti-doublon semaine, anti-récurrence 3 mois, anti-féculent commun, cooldowns 7 jours, pondération par notation).
- Bump V2.22.0 → V2.23.0.

## Mécanique du re-roll

```
Pour chaque jour :
  attempt = 0
  while attempt < 3 :
    attempt++
    snapshot des sets (usedThisWeek, dessertsCooldown, snacksCooldown)
    génère le slot complet (breakfast, lunch, dinner, snack, dessert)
    calcule CG du jour
    if tier ∈ {low, medium, unknown} → break, accepte
    if tier == high → restore sets, retry
  // Si 3 tentatives échouent → accepte dernier essai (best-effort)
```

## Comportement par profil santé

| Foyer | Seuil low/medium/high | Comportement V2.23 |
|---|---|---|
| Sans contraintes | 120 / 150 / 150 | Re-roll très rare, quasi-identique à V2.22 |
| Diabète T2 / SOPK / Insulinorésistance | 80 / 100 / 100 | Re-roll fréquent sur journées féculents-lourdes |
| Diabète T1 | 100 / 130 / 130 | Re-roll occasionnel |
| Dyslipidémies / Hypertension / Rééquilibrage | 100 / 120 / 120 | Re-roll occasionnel |
| Sportif endurance | (n/a, exclu du calcul) | Pas d'effet propre, fallback `healthy` si seul |

## Limites assumées

- Pas d'optimisation globale semaine (chaque jour indépendant).
- Pas d'alerte UI si > 2 jours tier `medium` (prévu V2.24+ si besoin remonté).
- Pool trop pauvre → fallback best-effort, l'UI affiche le badge rouge sur la journée pour signaler.
- Le re-roll restore intégralement les sets : si pool limité, il peut refaire un pick identique au tour suivant. La pondération aléatoire de `pickFromPool` amène progressivement vers une variante.

## Test plan
- [x] 9 tables JSON valides après refactor
- [x] Diff cohérent : +93 / -56 lignes (refactor wrapping)
- [x] Title + CACHE_VERSION alignés en V2.23.0
- [ ] Test foyer "sans contraintes" : pas de régression vs V2.22
- [ ] Test foyer avec membre SOPK : badges journée majoritairement verts après re-génération (re-roll actif)
- [ ] Test foyer aux contraintes incompatibles (toutes recettes hors pool) : fallback best-effort sans crash
- [ ] Test compatibilité locked : verrouiller un déjeuner, re-générer, vérifier que le verrou tient

## Phase 3 complète

V2.21.0 (foundation backend + UI bandeau/badges) + V2.21.1/V2.21.2 (renommage + fix UI Settings) + **V2.23.0 (intégration algo)** = chantier Phase 3 terminé.

Prochain coup selon cadence batch/feature : **Lot 10 recettes printemps/été** (V2.24.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
