### PR TITLE
V2.27.0 — Refactor shoppingDay : vraie fenêtre 7-jours alignée (issue #55 finale)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.26.0</title>
+<title>Menu IG Bas — V2.27.0</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -11159,8 +11159,25 @@ function mondayOf(date) {
   d.setDate(d.getDate() - day);
   return d;
 }
+// V2.27.0 — Renvoie le shoppingDay de la semaine contenant `date`. C'est
+// la "vraie fenêtre glissante" alignée sur le jour des courses du foyer.
+// shoppingDay : convention JS getDay() (0=Sun, 1=Mon, ..., 6=Sat).
+// Default 1 = lundi (= mondayOf, rétrocompat).
+function weekStartOf(date, shoppingDay = 1) {
+  if (shoppingDay === 1) return mondayOf(date);
+  const d = new Date(date); d.setHours(0,0,0,0);
+  const day = (d.getDay() - shoppingDay + 7) % 7;
+  d.setDate(d.getDate() - day);
+  return d;
+}
 function addDays(d, n){ const x = new Date(d); x.setDate(x.getDate()+n); return x; }
-function weekKey(d){ const m = mondayOf(d); return m.toISOString().slice(0,10); }
+// V2.27.0 — weekKey paramétrable. Pour shoppingDay=1 (default), comportement
+// identique à V2.26.0 : clé = lundi ISO de la semaine. Pour autre valeur,
+// clé = jour des courses ISO de la semaine.
+function weekKey(d, shoppingDay = 1){
+  const m = weekStartOf(d, shoppingDay);
+  return m.toISOString().slice(0,10);
+}
 function formatDateFR(d){
   return d.toLocaleDateString("fr-FR", {weekday:"long", day:"numeric", month:"long"});
 }
@@ -12139,7 +12156,10 @@ function generateWeek({profile, ratings, menus, weekStart, keepLocked}) {
   const snacks     = baseFilter("snack");
 
   const {set: recentlyUsed, lastUsedMap} = recipesUsedInLast3Months(menus, weekStart);
-  const existing = menus[weekKey(weekStart)] || {};
+  const sd = profile?.shoppingDay ?? 1;
+  // V2.27.0 — Lecture rétrocompat : on cherche d'abord la clé du shoppingDay
+  // courant ; si absent, fallback sur l'ancienne clé "lundi" (anciens menus).
+  const existing = menus[weekKey(weekStart, sd)] || (sd !== 1 ? (menus[weekKey(weekStart, 1)] || {}) : {});
 
   const days = {};
   const usedThisWeek = new Set();           // lunch + dinner anti-redondance
@@ -12616,18 +12636,28 @@ function RecoveryView({onResolved}) {
 
 function App({initialState}) {
   const [state, setState] = useState(initialState);
-  const [currentWeek, setCurrentWeek] = useState(mondayOf(new Date()));
+  const [currentWeek, setCurrentWeek] = useState(() => weekStartOf(new Date(), initialState?.profile?.shoppingDay ?? 1));
   const [view, setView] = useState(state.onboarded ? "menu" : "setup");
   const [selectedRecipe, setSelectedRecipe] = useState(null);
   const [printMode, setPrintMode] = useState(null); // null | "menu" | "shopping"
 
   useEffect(() => { saveState(state); }, [state]);
 
+  // V2.27.0 — Si shoppingDay change, on réaligne currentWeek sur la nouvelle
+  // fenêtre 7-jours pour que la vue planning reflète la nouvelle convention.
+  useEffect(() => {
+    const sd = state.profile?.shoppingDay ?? 1;
+    setCurrentWeek(prev => weekStartOf(prev, sd));
+  }, [state.profile?.shoppingDay]);
+
   const update = (updater) => setState(s => ({...s, ...(typeof updater === "function" ? updater(s) : updater)}));
   const updateProfile = (patch) => update(s => ({profile: {...s.profile, ...patch}}));
 
-  const wk = weekKey(currentWeek);
-  const currentMenu = state.menus[wk] || {};
+  const sd = state.profile?.shoppingDay ?? 1;
+  const wk = weekKey(currentWeek, sd);
+  // V2.27.0 — Lecture rétrocompat : si pas de menu pour la clé shoppingDay
+  // courant, fallback sur l'ancienne clé "lundi" (anciens menus pré-V2.27).
+  const currentMenu = state.menus[wk] || (sd !== 1 ? state.menus[weekKey(currentWeek, 1)] : null) || {};
 
   const regenerate = ({keepLocked = true} = {}) => {
     const days = generateWeek({
@@ -13202,8 +13232,9 @@ function MenuView({state, currentWeek, setCurrentWeek, currentMenu, regenerate, 
           {(() => {
             const ordered = daysOrderedFor(state.profile.shoppingDay ?? 1);
             return ordered.days.map((day, displayIdx) => {
-              const offsetIdx = ordered.offsetDays[displayIdx];
-              const date = addDays(currentWeek, offsetIdx);
+              // V2.27.0 — currentWeek est maintenant aligné sur shoppingDay,
+              // donc displayIdx donne directement l'offset jour.
+              const date = addDays(currentWeek, displayIdx);
               const slot = currentMenu[day] || {};
               const attendance = slot.attendance || {};
               const dayCg = computeDayCg(currentMenu, day, state.profile);
@@ -13811,10 +13842,12 @@ function MonthView({state, currentWeek, setCurrentWeek, update, onGoToWeek}) {
   const monthFmt = new Intl.DateTimeFormat("fr-FR", {month: "long", year: "numeric"});
 
   // Les 5 semaines glissantes à partir de currentWeek (ancre)
+  const sd = state.profile?.shoppingDay ?? 1;
   const weekInfos = [0,1,2,3,4].map(i => {
     const ws = addDays(currentWeek, i * 7);
-    const wk = weekKey(ws);
-    const menu = state.menus[wk] || {};
+    const wk = weekKey(ws, sd);
+    // Fallback rétrocompat : ancienne clé "lundi" si nouvelle pas trouvée.
+    const menu = state.menus[wk] || (sd !== 1 ? state.menus[weekKey(ws, 1)] : null) || {};
     let filled = 0, locks = 0;
     DAYS.forEach(d => {
       const slot = menu[d] || {};

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.26.0";
+const CACHE_VERSION = "menu-ig-bas-v2.27.0";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
Refactor profond pour finaliser l'**issue #55** : la "semaine de menu" devient une **vraie fenêtre glissante 7-jours** alignée sur le `shoppingDay` du foyer (au lieu de l'ancien lundi en dur).

Bump V2.26.0 → V2.27.0.

## Avant / Après

| | Avant V2.27.0 | Après V2.27.0 |
|---|---|---|
| shoppingDay = lundi (default) | Fenêtre lundi-dimanche | Fenêtre lundi-dimanche (identique) |
| shoppingDay = jeudi | Affichage "Jeudi" en 1ère colonne mais fenêtre logique lundi-dimanche | **Fenêtre jeudi-mercredi** complète (planning, liste de courses, mois, impression) |

HedgeX avait validé que la V2.25.0 minimale (réordonnement visuel uniquement) n'avait "aucun intérêt UX si on met pas en place la vraie fenêtre glissante" — ce refactor V2.27.0 livre l'effet attendu.

## Changements techniques

| Couche | Modification |
|---|---|
| `weekStartOf(date, shoppingDay)` | Nouvelle fonction, paramétrable, default 1 = lundi |
| `weekKey(d, shoppingDay)` | Paramétrée, fallback rétrocompat |
| `App` | `currentWeek` initialisé via `weekStartOf` ; `useEffect` qui réaligne si shoppingDay change |
| `App` | Lecture `state.menus[wk]` avec fallback rétrocompat → ancienne clé "lundi" si nouvelle absente |
| `generateWeek` | Reçoit `profile`, utilise `weekKey(weekStart, sd)` |
| `MonthView` | Itération weekInfos avec `weekKey(ws, sd)` + fallback |
| `MenuView` | `addDays(currentWeek, displayIdx)` au lieu de `addDays(currentWeek, offsetDays[displayIdx])` |

## Rétrocompatibilité

- **Foyer shoppingDay=1 (lundi)** : aucun changement de comportement. Tous les anciens menus restent indexés et affichés.
- **Foyer qui change shoppingDay** : 
  - Anciens menus (clé lundi) restent en DB.
  - Nouveaux menus stockés sous clé du `shoppingDay`.
  - Lecture avec **fallback automatique** vers l'ancienne clé si la nouvelle absente.
  - Les menus anciens restent visibles tant qu'ils ne sont pas regénérés.

## Limites assumées

- **Pas de migration des clés existantes** : si l'utilisateur change shoppingDay puis revient à lundi, les menus créés entre deux ne sont plus directement accessibles via la nav courante (sauf à remettre le shoppingDay correspondant à leur clé). Coût négligeable en DB (octets).
- **`aggregateShoppingList`** (liste de courses) itère sur `DAYS = lundi-dimanche`, mais les slots stockés portent le nom de leur jour. L'agrégation reste correcte quel que soit le shoppingDay (la fenêtre stockée contient bien les 7 noms).

## Test plan
- [x] 9 tables JSON valides
- [x] Title V2.27.0 unique
- [ ] **Default lundi** : tester un foyer existant avec shoppingDay = 1 → aucune régression vs V2.26.0
- [ ] **shoppingDay = jeudi** : changer dans Paramètres → planning passe sur fenêtre jeudi-mercredi, liste de courses agrège jeudi-mercredi, dates correctes
- [ ] **Régénération** sous nouveau shoppingDay : menu sauvegardé sous nouvelle clé
- [ ] **Fallback rétrocompat** : changer shoppingDay sur un foyer avec menus anciens (clé lundi) → menus toujours visibles via fallback
- [ ] **Vue mensuelle** : 5 semaines glissantes alignées sur shoppingDay
- [ ] **Impression A4** : titre "Semaine du X au Y" affiche bien la fenêtre shoppingDay

## Issue #55 — Finalisée

L'issue est fermable après merge et test concluants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
