### PR TITLE
V2.27.1 — Fix impression A4 alignée sur shoppingDay

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
 <meta charset="utf-8">
-<title>Menu IG Bas — V2.27.0</title>
+<title>Menu IG Bas — V2.27.1</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- PWA : permet l'installation sur l'écran d'accueil iOS / Android -->
 <link rel="manifest" href="manifest.json">
@@ -14730,11 +14730,17 @@ function PrintMenuPage({weekStart, menu, profile}) {
         </div>
         <div className="text-xs text-slate-500 dark:text-slate-400">Imprimé le {new Date().toLocaleDateString("fr-FR")}</div>
       </div>
+      {(() => {
+        // V2.27.1 — Itération alignée sur shoppingDay du foyer (cohérent
+        // avec MenuView V2.27.0). weekStart est déjà aligné, donc
+        // addDays(weekStart, i) donne directement la date du i-ème jour.
+        const orderedPrint = daysOrderedFor(profile?.shoppingDay ?? 1);
+        return (
       <table className="w-full border-collapse">
         <thead>
           <tr className="bg-emerald-700 text-white">
             <th className="border border-emerald-800 p-1 w-[90px]"></th>
-            {DAYS.map((d,i) => (
+            {orderedPrint.days.map((d,i) => (
               <th key={d} className="border border-emerald-800 p-1">
                 <div className="capitalize">{d}</div>
                 <div className="text-[8pt] font-normal opacity-80">{formatShort(addDays(weekStart,i))}</div>
@@ -14746,7 +14752,7 @@ function PrintMenuPage({weekStart, menu, profile}) {
           {rows.map(m => (
             <tr key={m.key}>
               <td className={`border border-slate-300 dark:border-slate-600 p-1 font-bold ${m.key === "dessert" ? "bg-rose-50 dark:bg-rose-950 text-rose-800 dark:text-rose-200" : m.key === "snack" ? "bg-amber-50 dark:bg-amber-950" : "bg-slate-100 dark:bg-slate-700"}`}>{m.icon} {m.label}</td>
-              {DAYS.map(d => {
+              {orderedPrint.days.map(d => {
                 const slot = menu[d] || {};
                 const r = RECIPES.find(x => x.id === slot[m.key]);
                 return (
@@ -14778,6 +14784,8 @@ function PrintMenuPage({weekStart, menu, profile}) {
           ))}
         </tbody>
       </table>
+        );
+      })()}
       <p className="text-[8pt] text-slate-500 dark:text-slate-400 mt-3 text-center">Menu IG Bas {(/V\d+\.\d+\.\d+/.exec(document.title)?.[0]) || ""} · prototype</p>
     </div>
   );

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@
 // Versioning du cache : bumper CACHE_VERSION à chaque release qui modifie
 // les ressources critiques. Les anciens caches sont purgés à l'activation.
 
-const CACHE_VERSION = "menu-ig-bas-v2.27.0";
+const CACHE_VERSION = "menu-ig-bas-v2.27.1";
 
 const CRITICAL_ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
Bug remonté par HedgeX : à l'impression A4 paysage du planning, les colonnes restaient ordonnées lundi-dimanche en dur même quand le foyer avait un autre `shoppingDay` (les dates étaient correctes mais l'ordre des colonnes ne suivait pas).

## Cause
`PrintMenuPage` (`index.html` ligne 14733+) itérait sur `DAYS` (constante lundi-dimanche) au lieu de `daysOrderedFor(shoppingDay)` introduit en V2.25.0/V2.27.0. Pattern récurrent (cf leçon #18 — modification UI incomplète sur composant dupliqué).

## Fix
- Wrap du `<table>` dans un IIFE qui appelle `daysOrderedFor(profile.shoppingDay ?? 1)`
- Utilisation de `ordered.days.map(...)` pour les 2 boucles map (header colonnes + chaque ligne de slot)
- Cohérent avec le fix MenuView de V2.27.0

## Vérification
`grep "DAYS.map" index.html` → **0 match** post-fix. Plus aucune itération hardcodée lundi-dimanche dans le code.

Bump V2.27.0 → V2.27.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
